### PR TITLE
Adding better error messaging for port ID check

### DIFF
--- a/pydsdl/dsdl_parser.py
+++ b/pydsdl/dsdl_parser.py
@@ -247,10 +247,13 @@ def parse_definition(definition:            DSDLDefinition,
         if not configuration_options.allow_unregulated_fixed_port_id:
             port_id = tout.fixed_port_id
             if port_id is not None:
-                f = is_valid_regulated_service_id if isinstance(tout, ServiceType) else is_valid_regulated_subject_id
+                is_service_type = isinstance(tout, ServiceType)
+                f = is_valid_regulated_service_id if is_service_type else is_valid_regulated_subject_id
                 if not f(port_id, tout.root_namespace):
-                    raise InvalidFixedPortIDError('Regulated port ID %r is not valid. '
-                                                  'Consider using allow_unregulated_fixed_port_id.' % port_id)
+                    type_msg = " for service type " if is_service_type else " for message type "
+                    raise InvalidFixedPortIDError('Regulated port ID %r%s\"%s\" is not valid. '
+                                                  'Consider using allow_unregulated_fixed_port_id.' % 
+                                                  (port_id, type_msg, tout.full_name))
 
         assert isinstance(tout, CompoundType)
         return tout

--- a/pydsdl/dsdl_parser.py
+++ b/pydsdl/dsdl_parser.py
@@ -251,7 +251,7 @@ def parse_definition(definition:            DSDLDefinition,
                 f = is_valid_regulated_service_id if is_service_type else is_valid_regulated_subject_id
                 if not f(port_id, tout.root_namespace):
                     type_msg = ' for service type ' if is_service_type else ' for message type '
-                    raise InvalidFixedPortIDError('Regulated port ID %r%s\"%s\" is not valid. '
+                    raise InvalidFixedPortIDError('Regulated port ID %r%s%r is not valid. '
                                                   'Consider using allow_unregulated_fixed_port_id.' % 
                                                   (port_id, type_msg, tout.full_name))
 

--- a/pydsdl/dsdl_parser.py
+++ b/pydsdl/dsdl_parser.py
@@ -250,7 +250,7 @@ def parse_definition(definition:            DSDLDefinition,
                 is_service_type = isinstance(tout, ServiceType)
                 f = is_valid_regulated_service_id if is_service_type else is_valid_regulated_subject_id
                 if not f(port_id, tout.root_namespace):
-                    type_msg = " for service type " if is_service_type else " for message type "
+                    type_msg = ' for service type ' if is_service_type else ' for message type '
                     raise InvalidFixedPortIDError('Regulated port ID %r%s\"%s\" is not valid. '
                                                   'Consider using allow_unregulated_fixed_port_id.' % 
                                                   (port_id, type_msg, tout.full_name))


### PR DESCRIPTION
Problem:
There's not enough information in the InvalidFixedPortIDError to
diagnose the real error.

Solution:
Include if the ID was for a service or message type and include the full
path. This allows the user to see which ID range they violated or if
this is just a path error.

Testing:
Fed invalid identifiers and verified that the message is more
informative.