### PR TITLE
Python compatibility clarifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 
 python:
   - '3.5.2'       # There have been compatibility issues with this patch version
+  - '3.5.3'
+  - '3.5.4'
+  - '3.5.5'
   - '3.5'
   - '3.6'
   - '3.7-dev'     # TODO: Replace with plain "3.7" when supported by Travis
@@ -20,4 +23,4 @@ script:
   - ./test.sh
   - coveralls  # Publish the coverage stats online.
   - git clone https://github.com/UAVCAN/dsdl --branch=uavcan-v1.0 dsdl-test  # TODO: Switch to master once v1.0 is merged
-  - python ./demo.py dsdl-test/uavcan  # Explicit "python" is needed to use the current Python version
+  - ./demo.py dsdl-test/uavcan

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
   - linux   # Travis does not support Python on OSX or Windows. Should we migrate to a different CI service?
 
 python:
-  - 3.5
-  - 3.6
-  - 3.7-dev     # TODO: Replace with plain "3.7" when supported by Travis
-#  - 3.8-dev    # TODO: Compatibility issues with MyPy, see https://travis-ci.org/UAVCAN/pydsdl/jobs/519988157
+  - '3.5'
+  - '3.6'
+  - '3.7-dev'     # TODO: Replace with plain "3.7" when supported by Travis
+#  - '3.8-dev'    # TODO: Compatibility issues with MyPy, see https://travis-ci.org/UAVCAN/pydsdl/jobs/519988157
 
 before_script:
   - pip install -r requirements.txt
@@ -18,4 +18,4 @@ script:
   - ./test.sh
   - coveralls  # Publish the coverage stats online.
   - git clone https://github.com/UAVCAN/dsdl --branch=uavcan-v1.0 dsdl-test  # TODO: Switch to master once v1.0 is merged
-  - ./demo.py dsdl-test/uavcan
+  - python ./demo.py dsdl-test/uavcan  # Explicit "python" is needed to use the current Python version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ os:
   - linux   # Travis does not support Python on OSX or Windows. Should we migrate to a different CI service?
 
 python:
-  - '3.5.2'       # There have been compatibility issues with this patch version
-  - '3.5.3'
-  - '3.5.4'
-  - '3.5.5'
+  - '3.5.3'       # Oldest supported version
   - '3.5'
   - '3.6'
   - '3.7-dev'     # TODO: Replace with plain "3.7" when supported by Travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - linux   # Travis does not support Python on OSX or Windows. Should we migrate to a different CI service?
 
 python:
+  - '3.5.2'       # There have been compatibility issues with this patch version
   - '3.5'
   - '3.6'
   - '3.7-dev'     # TODO: Replace with plain "3.7" when supported by Travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - pip install coveralls  # Intentionally removed from requirements.txt because it's only useful in the CI environment
 
 script:
+  - python --version
   - ./test.sh
   - coveralls  # Publish the coverage stats online.
   - git clone https://github.com/UAVCAN/dsdl --branch=uavcan-v1.0 dsdl-test  # TODO: Switch to master once v1.0 is merged

--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -6,8 +6,30 @@
 import os as _os
 import sys as _sys
 
-if _sys.version_info[:2] < (3, 5):   # pragma: no cover
-    print('A newer version of Python is required', file=_sys.stderr)
+# The original intent was to support Python 3.5 and newer; however, we have discovered a bug in the static typing
+# library in Python 3.5.2 which makes the library quite unusable: when importing, the typing module would throw
+# "TypeError: This Callable type is already parameterized." from the expression module. The problem does not appear
+# in Python 3.5.3 or any newer versions; it is fixed in the upstream here: https://github.com/python/typing/pull/308.
+# This is how you can reproduce it in REPL; first, the correct behavior that can be observed in Python 3.5.3+:
+#   >>> import typing
+#   >>> T = typing.TypeVar('T')
+#   >>> G = typing.Callable[[], T]
+#   >>> G[int]
+#   typing.Callable[[], int]
+# And this is what you get in Python 3.5.2-:
+#   >>> import typing
+#   >>> T = typing.TypeVar('T')
+#   >>> G = typing.Callable[[], T]
+#   >>> G[int]
+#   Traceback (most recent call last):
+#     File "<stdin>", line 1, in <module>
+#     File "/usr/lib/python3.5/typing.py", line 815, in __getitem__
+#       raise TypeError("This Callable type is already parameterized.")
+#   TypeError: This Callable type is already parameterized.
+_min_supported_python_version = 3, 5, 3
+if _sys.version_info[:3] < _min_supported_python_version:   # pragma: no cover
+    print('This package requires a Python version', '.'.join(map(str, _min_supported_python_version)), 'or newer',
+          file=_sys.stderr)
     _sys.exit(1)
 
 __version__ = 0, 7, 3

--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -32,7 +32,7 @@ if _sys.version_info[:3] < _min_supported_python_version:   # pragma: no cover
           file=_sys.stderr)
     _sys.exit(1)
 
-__version__ = 0, 7, 3
+__version__ = 0, 8, 0
 __license__ = 'MIT'
 
 # Our unorthodox approach to dependency management requires us to apply certain workarounds.


### PR DESCRIPTION
Python 3.5.2 turned out to be unsupported because there was an issue in the static typing library: https://github.com/python/typing/pull/308. The issue has been fixed in Python 3.5.3, so all newer versions function correctly. This is how you can reproduce the problem:

```python
>>> import typing
>>> T = typing.TypeVar('T')
>>> G = typing.Callable[[], T]
>>> G[int]
typing.Callable[[], int]
```

The above is the expected behavior observable in Python 3.5.3+. In 3.5.2 you get this instead:

```text
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/typing.py", line 815, in __getitem__
    raise TypeError("This Callable type is already parameterized.")
TypeError: This Callable type is already parameterized.
```

An alternative solution would be to remove the offending type annotations, which you can look at here: 

https://github.com/UAVCAN/pydsdl/blob/9a0bd72b4fd298e96c57f77e3c9a48b6fe1ee70a/pydsdl/_expression.py#L563-L565

However, I would rather not do that because that would require us to plaster the code with linter suppression comments and doing so for the sake of an ancient version of the interpreter (which will be EOLed next year) doesn't seem particularly sensible.

Should we accept this change, or should we add workarounds instead and retain compatibility with all v3.5.x?