### PR TITLE
Partial reversal of #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All of them share the same common ancestor `SerializableType` and the naming pat
     - `FixedLengthArrayType` - e.g., `uint8[256]`
     - `VariableLengthArrayType` - e.g., `uint8[<256]`
   - `CompositeType` - see below.
-    - `TaggedUnionType` - message types or nested structures.
+    - `UnionType` - message types or nested structures.
     - `StructureType` - message types or nested structures.
     - `ServiceType` - service types, not serializable.
 

--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -32,7 +32,7 @@ if _sys.version_info[:3] < _min_supported_python_version:   # pragma: no cover
           file=_sys.stderr)
     _sys.exit(1)
 
-__version__ = '1.3.1'
+__version__ = '1.4.0'
 __version_info__ = tuple(map(int, __version__.split('.')))
 __license__ = 'MIT'
 __author__ = 'UAVCAN Development Team'
@@ -70,7 +70,6 @@ from ._serializable import ArrayType as ArrayType
 from ._serializable import FixedLengthArrayType as FixedLengthArrayType
 from ._serializable import VariableLengthArrayType as VariableLengthArrayType
 from ._serializable import CompositeType as CompositeType
-from ._serializable import TaggedUnionType as TaggedUnionType
 from ._serializable import UnionType as UnionType
 from ._serializable import StructureType as StructureType
 from ._serializable import ServiceType as ServiceType

--- a/pydsdl/_bit_length_set.py
+++ b/pydsdl/_bit_length_set.py
@@ -197,7 +197,9 @@ class BitLengthSet:
         Computes the bit length set for a tagged union type given the bit length sets of each of its fields (variants).
         Unions are easy to handle because when serialized, a union is essentially just a single field prefixed with
         a fixed-length integer tag. So we just build a full set of combinations and then add the tag length
-        to each element.
+        to each element. Observe that unions are not defined for less than 2 elements; however, this function tries
+        to be generic by properly handling those cases as well, even though they are not permitted by the specification.
+        For zero fields, the function yields zero {0}; for one field, the function yields the BLS of the field itself.
         """
         ms = list(member_bit_length_sets)
         del member_bit_length_sets
@@ -210,8 +212,10 @@ class BitLengthSet:
         else:
             for s in ms:
                 out.unite_with(s)
-            unaligned_tag_bit_length = (len(ms) - 1).bit_length()
-            out.increment(2 ** math.ceil(math.log2(max(8, unaligned_tag_bit_length))))
+            # Add the union tag:
+            tag_bit_length = 2 ** math.ceil(math.log2(max(8, (len(ms) - 1).bit_length())))
+            out.increment(tag_bit_length)
+
         return out
 
     def __iter__(self) -> typing.Iterator[int]:

--- a/pydsdl/_data_type_builder.py
+++ b/pydsdl/_data_type_builder.py
@@ -60,7 +60,7 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
         if len(self._structs) == 1:     # Message type
             struct, = self._structs     # type: _data_schema_builder.DataSchemaBuilder,
             if struct.union:
-                out = _serializable.TaggedUnionType(
+                out = _serializable.UnionType(
                     name=self._definition.full_name,
                     version=self._definition.version,
                     attributes=struct.attributes,

--- a/pydsdl/_serializable/__init__.py
+++ b/pydsdl/_serializable/__init__.py
@@ -21,7 +21,6 @@ from ._array import FixedLengthArrayType as FixedLengthArrayType
 from ._array import VariableLengthArrayType as VariableLengthArrayType
 
 from ._composite import CompositeType as CompositeType
-from ._composite import TaggedUnionType as TaggedUnionType
 from ._composite import UnionType as UnionType
 from ._composite import StructureType as StructureType
 from ._composite import ServiceType as ServiceType

--- a/pydsdl/_serializable/_attribute.py
+++ b/pydsdl/_serializable/_attribute.py
@@ -19,14 +19,14 @@ class InvalidTypeError(TypeParameterError):
 
 
 class Attribute:    # TODO: should extend expression.Any to support advanced introspection/reflection.
-    def __init__(self, data_type: SerializableType, name: str, enforce_naming_rules: bool = True):
+    def __init__(self, data_type: SerializableType, name: str):
         self._data_type = data_type
         self._name = str(name)
 
         if isinstance(data_type, VoidType):
             if self._name:
                 raise InvalidNameError('Void-typed fields can be used only for padding and cannot be named')
-        elif enforce_naming_rules:
+        else:
             check_name(self._name)
 
     @property

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -170,7 +170,7 @@ def _unittest_simple() -> None:
     assert p.fields[0].name == 'request'
     assert p.fields[1].name == 'response'
     req, res = [x.data_type for x in p.fields]
-    assert isinstance(req, _serializable.TaggedUnionType)
+    assert isinstance(req, _serializable.UnionType)
     assert isinstance(res, _serializable.StructureType)
     assert req.full_name == 'another.Service.Request'
     assert res.full_name == 'another.Service.Response'
@@ -178,36 +178,25 @@ def _unittest_simple() -> None:
     assert res is p.response_type
 
     assert len(req.constants) == 0
-    assert len(req.fields) == 2
-    assert req.union_type.number_of_variants == 3
+    assert len(req.fields) == 3
+    assert req.number_of_variants == 3
     assert req.deprecated
     assert not req.has_fixed_port_id
     assert req.version == (0, 1)
     assert req.bit_length_set == 8   # Remember this is a union
-    assert [x.name for x in req.fields] == ['_tag_', '_union_']
-    assert [x.name for x in req.union_type.fields] == ['new_empty_implicit', 'new_empty_explicit', 'old_empty']
+    assert [x.name for x in req.fields] == ['new_empty_implicit', 'new_empty_explicit', 'old_empty']
 
     t = req.fields[0].data_type
-    assert isinstance(t, _serializable.UnsignedIntegerType)
-
-    t = req.fields[1].data_type
-    assert isinstance(t, _serializable.CompositeType)
-    assert t.full_name == 'another.Service.Request.union'
-    assert t.version == (0, 1)
-
-    union_type = t
-
-    t = union_type.fields[0].data_type
     assert isinstance(t, _serializable.StructureType)
     assert t.full_name == 'vendor.nested.Empty'
     assert t.version == (255, 255)          # Selected implicitly
 
-    t = union_type.fields[1].data_type
+    t = req.fields[1].data_type
     assert isinstance(t, _serializable.StructureType)
     assert t.full_name == 'vendor.nested.Empty'
     assert t.version == (255, 255)          # Selected explicitly
 
-    t = union_type.fields[2].data_type
+    t = req.fields[2].data_type
     assert isinstance(t, _serializable.StructureType)
     assert t.full_name == 'vendor.nested.Empty'
     assert t.version == (255, 254)          # Selected explicitly
@@ -261,18 +250,17 @@ def _unittest_simple() -> None:
     assert p.fixed_port_id is None
     assert not p.has_fixed_port_id
     assert not p.deprecated
-    assert isinstance(p, _serializable.TaggedUnionType)
-    assert p.union_type.number_of_variants == 3
+    assert isinstance(p, _serializable.UnionType)
+    assert p.number_of_variants == 3
     assert len(p.constants) == 1
     assert p.constants[0].name == 'PI'
     assert str(p.constants[0].data_type) == 'truncated float16'
     assert min(p.bit_length_set) == 8
     assert max(p.bit_length_set) == 8 + 8 + 255
-    assert len(p.fields) == 2
-    assert len(p.union_type.fields) == 3
-    assert str(p.union_type.fields[0]) == 'saturated uint8 a'
-    assert str(p.union_type.fields[1]) == 'vendor.nested.Empty.255.255[5] b'
-    assert str(p.union_type.fields[2]) == 'saturated bool[<=255] c'
+    assert len(p.fields) == 3
+    assert str(p.fields[0]) == 'saturated uint8 a'
+    assert str(p.fields[1]) == 'vendor.nested.Empty.255.255[5] b'
+    assert str(p.fields[2]) == 'saturated bool[<=255] c'
 
 
 # noinspection PyProtectedMember,PyProtectedMember
@@ -298,7 +286,7 @@ def _unittest_error() -> None:
     with raises(_error.InvalidDefinitionError, match='(?i).*multiple attributes under the same name.*'):
         standalone('vendor/AttributeNameCollision.1.0.uavcan', 'uint2 value\nint64 value')
 
-    with raises(_error.InvalidDefinitionError, match='(?i).*union cannot contain fewer than.*'):
+    with raises(_error.InvalidDefinitionError, match='(?i).*tagged union cannot contain fewer than.*'):
         standalone('vendor/SmallUnion.1.0.uavcan', '@union\nuint2 value')
 
     assert standalone('vendor/invalid_constant_value/A.1.0.uavcan',


### PR DESCRIPTION
TaggedUnionType removed, other changes left intact.

The reversal is done semi-manually by copying files from v1.2 and by reverting _test.py back to the pre-#34 state via git diff <range>; git apply.

See Slack for details.