### PR TITLE
Fix #41 and #42

### DIFF
--- a/.idea/dictionaries/pavel.xml
+++ b/.idea/dictionaries/pavel.xml
@@ -179,6 +179,7 @@
       <w>submoduling</w>
       <w>subnets</w>
       <w>subparser</w>
+      <w>subroot</w>
       <w>suka</w>
       <w>supernum</w>
       <w>supremum</w>

--- a/pydsdl/_dsdl_definition.py
+++ b/pydsdl/_dsdl_definition.py
@@ -35,17 +35,19 @@ class DSDLDefinition:
                  root_namespace_path: str):
         # Normalizing the path and reading the definition text
         self._file_path = os.path.abspath(file_path)
-        root_namespace_path = os.path.abspath(root_namespace_path)
+        del file_path
+        self._root_namespace_path = os.path.abspath(root_namespace_path)
+        del root_namespace_path
         with open(self._file_path) as f:
             self._text = str(f.read())
 
         # Checking the sanity of the root directory path - can't contain separators
-        if _serializable.CompositeType.NAME_COMPONENT_SEPARATOR in os.path.split(root_namespace_path)[-1]:
-            raise FileNameFormatError('Invalid namespace name', path=root_namespace_path)
+        if _serializable.CompositeType.NAME_COMPONENT_SEPARATOR in os.path.split(self._root_namespace_path)[-1]:
+            raise FileNameFormatError('Invalid namespace name', path=self._root_namespace_path)
 
         # Determining the relative path within the root namespace directory
-        relative_path = str(os.path.join(os.path.split(root_namespace_path)[-1],
-                                         os.path.relpath(self._file_path, root_namespace_path)))
+        relative_path = str(os.path.join(os.path.split(self._root_namespace_path)[-1],
+                                         os.path.relpath(self._file_path, self._root_namespace_path)))
 
         relative_directory, basename = [str(x) for x in os.path.split(relative_path)]   # type: str, str
 
@@ -194,6 +196,10 @@ class DSDLDefinition:
     @property
     def file_path(self) -> str:
         return self._file_path
+
+    @property
+    def root_namespace_path(self) -> str:
+        return self._root_namespace_path
 
     def __eq__(self, other: object) -> bool:
         """

--- a/pydsdl/_namespace.py
+++ b/pydsdl/_namespace.py
@@ -140,6 +140,9 @@ def read_namespace(root_namespace_directory:        str,
 
     # Construct DSDL definitions from the target and the lookup dirs.
     target_dsdl_definitions = _construct_dsdl_definitions_from_namespace(root_namespace_directory)
+    if not target_dsdl_definitions:
+        _logger.info('The namespace at %r is empty', root_namespace_directory)
+        return []
     _logger.debug('Target DSDL definitions are listed below:')
     for x in target_dsdl_definitions:
         _logger.debug(_LOG_LIST_ITEM_PREFIX + str(x))

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -676,6 +676,9 @@ def _unittest_parse_namespace() -> None:
         with open(path, 'w') as f:
             f.write(text)
 
+    # Empty namespace.
+    assert [] == _namespace.read_namespace(directory.name)
+
     _define(
         'zubax/First.1.0.uavcan',
         dedent("""
@@ -722,10 +725,10 @@ def _unittest_parse_namespace() -> None:
     assert 'zubax.nested.Spartans' in [x.full_name for x in parsed]
 
     # try again with minimal arguments to read_namespace
-    parsed_minmal_args = _namespace.read_namespace(
+    parsed_minimal_args = _namespace.read_namespace(
         os.path.join(directory.name, 'zubax')
     )
-    assert len(parsed_minmal_args) == 3
+    assert len(parsed_minimal_args) == 3
 
     _define(
         'zubax/colliding/300.Iceberg.30.0.uavcan',

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -66,6 +66,7 @@ def _unittest_define() -> None:
     assert d.version == (1, 2)
     assert d.fixed_port_id == 5000
     assert d.file_path == os.path.join(_DIRECTORY.name, 'uavcan', 'test', '5000.Message.1.2.uavcan')
+    assert d.root_namespace_path == os.path.join(_DIRECTORY.name, 'uavcan')
     assert open(d.file_path).read() == '# empty'
 
     # BUT WHEN I DO, I WRITE UNIT TESTS FOR MY UNIT TESTS
@@ -74,6 +75,7 @@ def _unittest_define() -> None:
     assert d.version == (255, 254)
     assert d.fixed_port_id is None
     assert d.file_path == os.path.join(_DIRECTORY.name, 'uavcan', 'Service.255.254.uavcan')
+    assert d.root_namespace_path == os.path.join(_DIRECTORY.name, 'uavcan')
     assert open(d.file_path).read() == '# empty 2'
 
 
@@ -374,6 +376,9 @@ def _unittest_error() -> None:
 
     with raises(_data_type_builder.UndefinedDataTypeError, match=r'(?i).*nonexistent.TypeName.*1\.0.*'):
         standalone('vendor/types/A.1.0.uavcan', 'nonexistent.TypeName.1.0 field')
+
+    with raises(_data_type_builder.UndefinedDataTypeError, match=r"(?i).*/vendor/types' instead of .*/vendor'.*"):
+        standalone('vendor/types/A.1.0.uavcan', 'types.Nonexistent.1.0 field')
 
     with raises(_error.InvalidDefinitionError, match=r'(?i).*not defined for.*'):
         standalone('vendor/types/A.1.0.uavcan',

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -377,7 +377,7 @@ def _unittest_error() -> None:
     with raises(_data_type_builder.UndefinedDataTypeError, match=r'(?i).*nonexistent.TypeName.*1\.0.*'):
         standalone('vendor/types/A.1.0.uavcan', 'nonexistent.TypeName.1.0 field')
 
-    with raises(_data_type_builder.UndefinedDataTypeError, match=r"(?i).*/vendor/types' instead of .*/vendor'.*"):
+    with raises(_data_type_builder.UndefinedDataTypeError, match=r"(?i).*vendor[/\\]+types' instead of .*vendor'.*"):
         standalone('vendor/types/A.1.0.uavcan', 'types.Nonexistent.1.0 field')
 
     with raises(_error.InvalidDefinitionError, match=r'(?i).*not defined for.*'):


### PR DESCRIPTION
Fixes #41
Fixes #42

Now, in case of an accidental misuse like in https://forum.uavcan.org/t/dsdl-compilation-error/904/2, the error message will contain a helpful suggestion:

```
/home/pavel/test/demo/dsdl/my_namespace/Trajectory.1.0.uavcan:1: Data type my_namespace.PointXY.1.0 could not be found in the following root namespaces: {'dsdl'}.  Did you mean to use the directory '/home/pavel/test/demo/dsdl/my_namespace' instead of '/home/pavel/test/demo/dsdl'?
```