### PR TITLE
Performance improvements; fix #49

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -6,7 +6,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = '1.6.3'
+__version__ = '1.6.4'
 __version_info__ = tuple(map(int, __version__.split('.')))
 __license__ = 'MIT'
 __author__ = 'UAVCAN Development Team'

--- a/pydsdl/_bit_length_set.py
+++ b/pydsdl/_bit_length_set.py
@@ -36,7 +36,7 @@ class BitLengthSet:
             values = set()
         elif isinstance(values, int):
             values = {values}
-        else:
+        elif not isinstance(values, set):
             values = set(map(int, values))
 
         if values and min(values) < 0:

--- a/pydsdl/_bit_length_set.py
+++ b/pydsdl/_bit_length_set.py
@@ -39,7 +39,7 @@ class BitLengthSet:
         else:
             values = set(map(int, values))
 
-        if not all(map(lambda x: x >= 0, values)):
+        if values and min(values) < 0:
             raise ValueError('Bit length set elements cannot be negative: %r' % values)
 
         assert isinstance(values, set)

--- a/pydsdl/_bit_length_set.py
+++ b/pydsdl/_bit_length_set.py
@@ -43,7 +43,6 @@ class BitLengthSet:
             raise ValueError('Bit length set elements cannot be negative: %r' % values)
 
         assert isinstance(values, set)
-        assert all(map(lambda x: isinstance(x, int) and x >= 0, values))
         self._value = values  # type: typing.Set[int]
 
     def is_aligned_at(self, bit_length: int) -> bool:

--- a/pydsdl/_bit_length_set.py
+++ b/pydsdl/_bit_length_set.py
@@ -36,15 +36,13 @@ class BitLengthSet:
         BitLengthSet({1, 2, 3})
         """
         if isinstance(values, set):
-            pass  # Do not convert if already a set
+            self._value = values  # Do not convert if already a set
         elif values is None:
-            values = set()
+            self._value = set()
         elif isinstance(values, int):
-            values = {values}
+            self._value = {values}
         else:
-            values = set(map(int, values))
-
-        self._value = values  # type: typing.Set[int]
+            self._value = set(map(int, values))
 
     def is_aligned_at(self, bit_length: int) -> bool:
         """


### PR DESCRIPTION
Fix #49

Performance profiling script:

```python
#!/usr/bin/env python
import sys
import pathlib
import cProfile
sys.path.append(str(pathlib.Path(__file__).parent))
import pydsdl
cProfile.run('''pydsdl.read_namespace('.dsdl-test/uavcan', [])''', sort=1)
```

This PR brings the execution time of the above script from 63 seconds down to 3 seconds. It is possible to do better but it wouldn't be trivial. Maybe we need dsdl.rs?

Alternative profiling script that also parses the `reg` namespace:

```python
#!/usr/bin/env python
import sys
import pathlib
import cProfile
sys.path.append(str(pathlib.Path(__file__).parent))
import pydsdl
cProfile.run('''
pydsdl.read_namespace('.dsdl-test/reg', ['.dsdl-test/uavcan'])
pydsdl.read_namespace('.dsdl-test/uavcan', [])
''', sort=1)
```