### PR TITLE
Make `@sealed` or `@extent ...` required. Provide usage hints when neither are found.

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -6,7 +6,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = '1.7.0'
+__version__ = '1.8.0'
 __version_info__ = tuple(map(int, __version__.split('.')))
 __license__ = 'MIT'
 __author__ = 'UAVCAN Development Team'

--- a/pydsdl/_namespace.py
+++ b/pydsdl/_namespace.py
@@ -96,7 +96,7 @@ def read_namespace(root_namespace_directory:        str,
     It reads all DSDL definitions from the specified root namespace directory and produces the annotated AST.
 
     :param root_namespace_directory: The path of the root namespace directory that will be read.
-        For example, "dsdl/uavcan" to read the "uavcan" namespace.
+        For example, ``dsdl/uavcan`` to read the ``uavcan`` namespace.
 
     :param lookup_directories: List of other namespace directories containing data type definitions that are
         referred to from the target root namespace. For example, if you are reading a vendor-specific namespace,

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -516,8 +516,8 @@ class DelimitedType(CompositeType):
     @property
     def extent(self) -> int:
         """
-        The extent of a delimited type can be specified explicitly via ``@extent`` (provided that it is not less
-        than the minimum); otherwise, it defaults to ``floor(inner_type.extent * 3/2)`` padded to byte.
+        The extent of a delimited type is specified explicitly via ``@extent EXPRESSION``,
+        where the expression shall yield an integer multiple of 8.
 
         Optional optimization hint: if the objective is to allocate buffer memory for constructing a new
         serialized representation locally, then it may be beneficial to use the extent of the inner type

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -3,11 +3,11 @@
 # This software is distributed under the terms of the MIT License.
 #
 
+import os
 import abc
 import math
 import typing
 import itertools
-import fractions
 from .. import _expression
 from .. import _port_id_ranges
 from .._bit_length_set import BitLengthSet
@@ -57,13 +57,13 @@ class CompositeType(SerializableType):
     NAME_COMPONENT_SEPARATOR = '.'
 
     def __init__(self,
-                 name:             str,
-                 version:          Version,
-                 attributes:       typing.Iterable[Attribute],
-                 deprecated:       bool,
-                 fixed_port_id:    typing.Optional[int],
-                 source_file_path: str,
-                 parent_service:   typing.Optional['ServiceType'] = None):
+                 name:                  str,
+                 version:               Version,
+                 attributes:            typing.Iterable[Attribute],
+                 deprecated:            bool,
+                 fixed_port_id:         typing.Optional[int],
+                 source_file_path:      str,
+                 parent_service_getter: typing.Optional[typing.Callable[[], typing.Optional['ServiceType']]] = None):
         super(CompositeType, self).__init__()
 
         self._name = str(name).strip()
@@ -73,12 +73,7 @@ class CompositeType(SerializableType):
         self._deprecated = bool(deprecated)
         self._fixed_port_id = None if fixed_port_id is None else int(fixed_port_id)
         self._source_file_path = str(source_file_path)
-        self._parent_service = parent_service
-
-        if self._parent_service is not None:
-            assert self._name.endswith('.Request') or self._name.endswith('.Response')
-            if not isinstance(self._parent_service, ServiceType):  # pragma: no cover
-                raise ValueError('The parent service reference is invalid: %s' % type(parent_service).__name__)
+        self._parent_service_getter = parent_service_getter if parent_service_getter is not None else lambda: None
 
         # Name check
         if not self._name:
@@ -87,8 +82,13 @@ class CompositeType(SerializableType):
         if self.NAME_COMPONENT_SEPARATOR not in self._name:
             raise InvalidNameError('Root namespace is not specified')
 
-        # Do not check name length for synthesized types.
-        if len(self._name) > self.MAX_NAME_LENGTH and parent_service is None:
+        if len(self._name) > self.MAX_NAME_LENGTH:
+            # TODO
+            # Notice that per the Specification, service request/response types are unnamed,
+            # but we actually name them the same as the parent service plus the ".Request"/".Response" suffix.
+            # This may trigger a name length error for long-named service types where per the Specification
+            # no such error may occur. We expect the Specification to catch up with this behavior in a later
+            # revision where the names for the request and response parts are actually properly specified.
             raise InvalidNameError('Name is too long: %r is longer than %d characters' %
                                    (self._name, self.MAX_NAME_LENGTH))
 
@@ -232,7 +232,7 @@ class CompositeType(SerializableType):
         :class:`pydsdl.ServiceType` contains two special fields of this type: ``request`` and ``response``.
         For them this property points to the parent service instance; otherwise it's None.
         """
-        return self._parent_service
+        return self._parent_service_getter()
 
     @abc.abstractmethod
     def iterate_fields_with_offsets(self, base_offset: typing.Optional[BitLengthSet] = None) \
@@ -319,13 +319,13 @@ class UnionType(CompositeType):
     MIN_NUMBER_OF_VARIANTS = 2
 
     def __init__(self,
-                 name:             str,
-                 version:          Version,
-                 attributes:       typing.Iterable[Attribute],
-                 deprecated:       bool,
-                 fixed_port_id:    typing.Optional[int],
-                 source_file_path: str,
-                 parent_service:   typing.Optional['ServiceType'] = None):
+                 name:                  str,
+                 version:               Version,
+                 attributes:            typing.Iterable[Attribute],
+                 deprecated:            bool,
+                 fixed_port_id:         typing.Optional[int],
+                 source_file_path:      str,
+                 parent_service_getter: typing.Optional[typing.Callable[[], 'ServiceType']] = None):
         # Proxy all parameters directly to the base type - I wish we could do that
         # with kwargs while preserving the type information
         super(UnionType, self).__init__(name=name,
@@ -334,7 +334,7 @@ class UnionType(CompositeType):
                                         deprecated=deprecated,
                                         fixed_port_id=fixed_port_id,
                                         source_file_path=source_file_path,
-                                        parent_service=parent_service)
+                                        parent_service_getter=parent_service_getter)
 
         if self.number_of_variants < self.MIN_NUMBER_OF_VARIANTS:
             raise MalformedUnionError('A tagged union cannot contain fewer than %d variants' %
@@ -474,14 +474,9 @@ class DelimitedType(CompositeType):
     56 bits long, then version 3 could grow to 96 bits, unpredictable).
     """
 
-    DEFAULT_EXTENT_MULTIPLIER = fractions.Fraction(3, 2)
-    """
-    If the extent is not specified explicitly, it is computed by multiplying the extent of the inner type by this.
-    """
-
     _DEFAULT_DELIMITER_HEADER_BIT_LENGTH = 32
 
-    def __init__(self, inner: CompositeType, extent: typing.Optional[int]):
+    def __init__(self, inner: CompositeType, extent: int):
         self._inner = inner
         super(DelimitedType, self).__init__(name=inner.full_name,
                                             version=inner.version,
@@ -489,13 +484,8 @@ class DelimitedType(CompositeType):
                                             deprecated=inner.deprecated,
                                             fixed_port_id=inner.fixed_port_id,
                                             source_file_path=inner.source_file_path,
-                                            parent_service=inner.parent_service)
-        if extent is None:
-            unaligned = math.floor(inner.extent * self.DEFAULT_EXTENT_MULTIPLIER)
-            self._extent = max(BitLengthSet(unaligned).pad_to_alignment(self.alignment_requirement))
-        else:
-            self._extent = int(extent)
-
+                                            parent_service_getter=lambda: inner.parent_service)
+        self._extent = int(extent)
         if self._extent % self.alignment_requirement != 0:
             raise InvalidExtentError('The specified extent of %d bits is not a multiple of %d bits' %
                                      (self._extent, self.alignment_requirement))
@@ -507,7 +497,6 @@ class DelimitedType(CompositeType):
                 (self._extent, inner.extent)
             )
 
-        # Invariant checks.
         assert self.extent % self.BITS_PER_BYTE == 0
         assert self.extent % self.alignment_requirement == 0
         assert self.extent >= self.inner_type.extent
@@ -589,71 +578,31 @@ class ServiceType(CompositeType):
     which contain the request and the response structure of the service type, respectively.
     """
 
-    class SchemaParams:
-        """A trivial helper dataclass used for constructing new instances."""
-        def __init__(self,
-                     attributes: typing.Iterable[Attribute],
-                     extent:     typing.Optional[int],
-                     is_sealed:  bool,
-                     is_union:   bool):
-            self.attributes = list(attributes)
-            self.extent = int(extent) if extent is not None else None
-            self.is_sealed = bool(is_sealed)
-            self.is_union = bool(is_union)
-            if self.is_sealed and self.extent is not None:  # pragma: no cover
-                raise ValueError('API misuse: cannot set the extent on a sealed type')
+    def __init__(self, request: CompositeType, response: CompositeType, fixed_port_id: typing.Optional[int]):
+        name = request.full_namespace
+        consistent = (
+            request.full_name.startswith(name) and response.full_name.startswith(name) and
+            request.version == response.version and
+            not isinstance(request, ServiceType) and not isinstance(response, ServiceType) and
+            request.deprecated == response.deprecated and
+            request.source_file_path == response.source_file_path and
+            request.fixed_port_id is None and response.fixed_port_id is None
+        )
+        if not consistent:
+            raise ValueError('Internal error: service request/response type consistency error')
 
-        def construct_composite(self,
-                                name: str,
-                                version: Version,
-                                deprecated: bool,
-                                parent_service: 'ServiceType',
-                                source_file_path: str) -> CompositeType:
-            request_meta_type = UnionType if self.is_union else StructureType  # type: type
-            ty = request_meta_type(name=name,
-                                   version=version,
-                                   attributes=self.attributes,
-                                   deprecated=deprecated,
-                                   fixed_port_id=None,
-                                   source_file_path=source_file_path,
-                                   parent_service=parent_service)
-            assert isinstance(ty, CompositeType)
-            if self.is_sealed:
-                assert self.extent is None
-                return ty
-            else:
-                return DelimitedType(ty, extent=self.extent)
-
-    def __init__(self,
-                 name:             str,
-                 version:          Version,
-                 request_params:   SchemaParams,
-                 response_params:  SchemaParams,
-                 deprecated:       bool,
-                 fixed_port_id:    typing.Optional[int],
-                 source_file_path: str):
-        self._request_type = request_params.construct_composite(name=name + '.Request',
-                                                                version=version,
-                                                                deprecated=deprecated,
-                                                                parent_service=self,
-                                                                source_file_path=source_file_path)
-        self._response_type = response_params.construct_composite(name=name + '.Response',
-                                                                  version=version,
-                                                                  deprecated=deprecated,
-                                                                  parent_service=self,
-                                                                  source_file_path=source_file_path)
+        self._request_type = request
+        self._response_type = response
         container_attributes = [
             Field(data_type=self._request_type,  name='request'),
             Field(data_type=self._response_type, name='response'),
         ]
         super(ServiceType, self).__init__(name=name,
-                                          version=version,
+                                          version=request.version,
                                           attributes=container_attributes,
-                                          deprecated=deprecated,
+                                          deprecated=request.deprecated,
                                           fixed_port_id=fixed_port_id,
-                                          source_file_path=source_file_path)
-        assert self.request_type.parent_service is self
-        assert self.response_type.parent_service is self
+                                          source_file_path=request.source_file_path)
 
     @property
     def bit_length_set(self) -> BitLengthSet:
@@ -661,12 +610,12 @@ class ServiceType(CompositeType):
 
     @property
     def request_type(self) -> CompositeType:
-        """The type of the request schema."""
+        assert self._request_type.parent_service is self
         return self._request_type
 
     @property
     def response_type(self) -> CompositeType:
-        """The type of the response schema."""
+        assert self._response_type.parent_service is self
         return self._response_type
 
     def iterate_fields_with_offsets(self, base_offset: typing.Optional[BitLengthSet] = None) \
@@ -716,14 +665,6 @@ def _unittest_composite_types() -> None:
     assert try_name('root.nested.T').full_namespace == 'root.nested'
     assert try_name('root.nested.T').root_namespace == 'root'
     assert try_name('root.nested.T').short_name == 'T'
-
-    print(ServiceType(name='a' * 48 + '.T',     # No exception raised
-                      version=Version(0, 1),
-                      request_params=ServiceType.SchemaParams([], None, False, False),
-                      response_params=ServiceType.SchemaParams([], None, False, False),
-                      deprecated=False,
-                      fixed_port_id=None,
-                      source_file_path=''))
 
     with raises(MalformedUnionError, match='.*variants.*'):
         UnionType(name='a.A',
@@ -789,7 +730,7 @@ def _unittest_composite_types() -> None:
         assert s['']        # Padding fields are not accessible
     assert hash(s) == hash(s)
 
-    d = DelimitedType(s, None)
+    d = DelimitedType(s, 2048)
     assert d.inner_type is s
     assert d.attributes == d.inner_type.attributes
     with raises(KeyError):
@@ -797,7 +738,7 @@ def _unittest_composite_types() -> None:
     assert hash(d) == hash(d)
     assert d.delimiter_header_type.bit_length == 32
     assert isinstance(d.delimiter_header_type, UnsignedIntegerType)
-    assert d.extent == d.inner_type.extent * 3 // 2
+    assert d.extent == 2048
 
     d = DelimitedType(s, 256)
     assert hash(d) == hash(d)
@@ -835,8 +776,8 @@ def _unittest_composite_types() -> None:
     ])
     assert u.bit_length_set == {24}
     assert u.extent == 24
-    assert DelimitedType(u, None).extent == 40
-    assert DelimitedType(u, None).bit_length_set == {32, 40, 48, 56, 64, 72}
+    assert DelimitedType(u, 40).extent == 40
+    assert DelimitedType(u, 40).bit_length_set == {32, 40, 48, 56, 64, 72}
     assert DelimitedType(u, 24).extent == 24
     assert DelimitedType(u, 24).bit_length_set == {32, 40, 48, 56}
     assert DelimitedType(u, 32).extent == 32
@@ -886,8 +827,8 @@ def _unittest_composite_types() -> None:
     ])
     assert s.bit_length_set == {32}
     assert s.extent == 32
-    assert DelimitedType(s, None).extent == 48
-    assert DelimitedType(s, None).bit_length_set == {32, 40, 48, 56, 64, 72, 80}
+    assert DelimitedType(s, 48).extent == 48
+    assert DelimitedType(s, 48).bit_length_set == {32, 40, 48, 56, 64, 72, 80}
     assert DelimitedType(s, 32).extent == 32
     assert DelimitedType(s, 32).bit_length_set == {32, 40, 48, 56, 64}
     assert DelimitedType(s, 40).extent == 40
@@ -953,7 +894,7 @@ def _unittest_field_iterators() -> None:
         }),
     ])
 
-    d = DelimitedType(a, None)
+    d = DelimitedType(a, 472)
     validate_iterator(d, [
         ('a', {32 + 0}),
         ('b', {32 + 10}),
@@ -1108,13 +1049,21 @@ def _unittest_field_iterators() -> None:
     ], BitLengthSet({0, 4, 8}))  # The option 4 is eliminated due to padding to byte, so we're left with {0, 8}.
 
     with raises(TypeError, match='.*request or response.*'):
-        ServiceType(name='ns.S',
-                    version=Version(1, 0),
-                    request_params=ServiceType.SchemaParams([], None, False, False),
-                    response_params=ServiceType.SchemaParams([], None, False, False),
-                    deprecated=False,
-                    fixed_port_id=None,
-                    source_file_path='').iterate_fields_with_offsets()
+        ServiceType(request=StructureType(name='ns.S.Request',
+                                          version=Version(1, 0),
+                                          attributes=[],
+                                          deprecated=False,
+                                          fixed_port_id=None,
+                                          source_file_path='',
+                                          parent_service_getter=None),
+                    response=StructureType(name='ns.S.Response',
+                                           version=Version(1, 0),
+                                           attributes=[],
+                                           deprecated=False,
+                                           fixed_port_id=None,
+                                           source_file_path='',
+                                           parent_service_getter=None),
+                    fixed_port_id=None).iterate_fields_with_offsets()
 
     # Check the auto-padding logic.
     e = StructureType(name='e.E',

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -3,7 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-import os
 import abc
 import math
 import typing

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -88,6 +88,7 @@ def _unittest_simple() -> None:
         uint8 CHARACTER = '#'
         int8 a
         saturated int64[<33] b
+        @extent 1024 * 8
         ''')
     )
     assert abc.fixed_port_id == 7000
@@ -107,7 +108,7 @@ def _unittest_simple() -> None:
     assert min(p.inner_type.bit_length_set) == 16
     assert max(p.inner_type.bit_length_set) == 16 + 64 * 32
     assert min(p.bit_length_set) == 32
-    assert max(p.bit_length_set) == 32 + (16 + 64 * 32) * 3 // 2
+    assert max(p.bit_length_set) == 32 + 1024 * 8
     assert len(p.attributes) == 3
     assert len(p.fields) == 2
     assert str(p.fields[0].data_type) == 'saturated int8'
@@ -219,7 +220,7 @@ def _unittest_simple() -> None:
     assert res.version == (0, 1)
     # This is a sealed type, so we get the real BLS, but we mustn't forget about the non-sealed nested field!
     assert min(res.bit_length_set) == 32                                            # Just the delimiter header
-    assert max(res.bit_length_set) == 32 + (16 + 64 * 32) * 3 // 2
+    assert max(res.bit_length_set) == 32 + 1024 * 8
 
     t = res.fields[0].data_type
     assert isinstance(t, _serializable.StructureType)
@@ -286,111 +287,112 @@ def _unittest_error() -> None:
         return _define(rel_path, definition + '\n').read([], lambda *_: None, allow_unregulated)  # pragma: no branch
 
     with raises(_error.InvalidDefinitionError, match='(?i).*port ID.*'):
-        standalone('vendor/1000.InvalidRegulatedSubjectID.1.0.uavcan', 'uint2 value')
+        standalone('vendor/1000.InvalidRegulatedSubjectID.1.0.uavcan', 'uint2 value\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*port ID.*'):
-        standalone('vendor/10.InvalidRegulatedServiceID.1.0.uavcan', 'uint2 v1\n---\nint64 v2')
+        standalone('vendor/10.InvalidRegulatedServiceID.1.0.uavcan', 'uint2 v1\n@sealed\n---\nint64 v2\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*subject ID.*'):
-        standalone('vendor/100000.InvalidRegulatedSubjectID.1.0.uavcan', 'uint2 value')
+        standalone('vendor/100000.InvalidRegulatedSubjectID.1.0.uavcan', 'uint2 value\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*service ID.*'):
-        standalone('vendor/1000.InvalidRegulatedServiceID.1.0.uavcan', 'uint2 v1\n---\nint64 v2')
+        standalone('vendor/1000.InvalidRegulatedServiceID.1.0.uavcan', 'uint2 v1\n@sealed\n---\nint64 v2\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*multiple attributes under the same name.*'):
-        standalone('vendor/AttributeNameCollision.1.0.uavcan', 'uint2 value\nint64 value')
+        standalone('vendor/AttributeNameCollision.1.0.uavcan', 'uint2 value\n@sealed\nint64 value')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*tagged union cannot contain fewer than.*'):
-        standalone('vendor/SmallUnion.1.0.uavcan', '@union\nuint2 value')
+        standalone('vendor/SmallUnion.1.0.uavcan', '@union\nuint2 value\n@sealed')
 
     assert standalone('vendor/invalid_constant_value/A.1.0.uavcan',
-                      'bool BOOLEAN = false').constants[0].name == 'BOOLEAN'
+                      'bool BOOLEAN = false\n@sealed').constants[0].name == 'BOOLEAN'
     with raises(_error.InvalidDefinitionError, match='.*Invalid value for boolean constant.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'bool BOOLEAN = 0')   # Should be false
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'bool BOOLEAN = 0\n@extent 0')   # Should be false
 
     with raises(_error.InvalidDefinitionError, match='.*undefined_identifier.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'bool BOOLEAN = undefined_identifier')
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'bool BOOLEAN = undefined_identifier\n@extent 0')
 
     with raises(_parser.DSDLSyntaxError):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'bool BOOLEAN = -')
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'bool BOOLEAN = -\n@extent 0')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*exceeds the range.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'uint10 INTEGRAL = 2000')
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', 'uint10 INTEGRAL = 2000\n@extent 0')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*character.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "uint8 CH = '\u0451'")
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "uint8 CH = '\u0451'\n@extent 0")
 
     with raises(_error.InvalidDefinitionError, match='.*uint8.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "uint9 CH = 'q'")
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "uint9 CH = 'q'\n@extent 0")
 
     with raises(_error.InvalidDefinitionError, match='.*uint8.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "int8 CH = 'q'")
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "int8 CH = 'q'\n@extent 0")
 
     with raises(_error.InvalidDefinitionError, match='.*integer constant.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "int8 CH = 1.1")
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "int8 CH = 1.1\n@extent 0")
 
     with raises(_error.InvalidDefinitionError, match='(?i).*type.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "float32 CH = true")
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "float32 CH = true\n@extent 0")
 
     with raises(_error.InvalidDefinitionError, match='(?i).*type.*'):
-        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "float32 CH = 't'")
+        standalone('vendor/invalid_constant_value/A.1.0.uavcan', "float32 CH = 't'\n@extent 0")
 
     with raises(_parser.DSDLSyntaxError):
-        standalone('vendor/syntax_error/A.1.0.uavcan', 'bool array[10]')
+        standalone('vendor/syntax_error/A.1.0.uavcan', 'bool array[10]\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*array capacity.*'):
-        standalone('vendor/array_size/A.1.0.uavcan', 'bool[0] array')
+        standalone('vendor/array_size/A.1.0.uavcan', 'bool[0] array\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*array capacity.*'):
-        standalone('vendor/array_size/A.1.0.uavcan', 'bool[<1] array')
+        standalone('vendor/array_size/A.1.0.uavcan', 'bool[<1] array\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*array capacity.*'):
-        standalone('vendor/array_size/A.1.0.uavcan', 'bool[true] array')
+        standalone('vendor/array_size/A.1.0.uavcan', 'bool[true] array\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*array capacity.*'):
-        standalone('vendor/array_size/A.1.0.uavcan', 'bool["text"] array')
+        standalone('vendor/array_size/A.1.0.uavcan', 'bool["text"] array\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*service response marker.*'):
-        standalone('vendor/service/A.1.0.uavcan', 'bool request\n---\nbool response\n---\nbool again')
+        standalone('vendor/service/A.1.0.uavcan',
+                   'bool request\n@sealed\n---\nbool response\n@sealed\n---\nbool again\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*unknown directive.*'):
-        standalone('vendor/directive/A.1.0.uavcan', '@sho_tse_take')
+        standalone('vendor/directive/A.1.0.uavcan', '@sho_tse_take\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*requires an expression.*'):
-        standalone('vendor/directive/A.1.0.uavcan', '@assert')
+        standalone('vendor/directive/A.1.0.uavcan', '@assert\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*does not expect an expression.*'):
-        standalone('vendor/directive/A.1.0.uavcan', '@union true || false')
+        standalone('vendor/directive/A.1.0.uavcan', '@union true || false\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*does not expect an expression.*'):
-        standalone('vendor/directive/A.1.0.uavcan', '@deprecated true || false')
+        standalone('vendor/directive/A.1.0.uavcan', '@deprecated true || false\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*version number.*'):
-        standalone('vendor/version/A.0.0.uavcan', '')
+        standalone('vendor/version/A.0.0.uavcan', '@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*version number.*'):
-        standalone('vendor/version/A.0.256.uavcan', '')
+        standalone('vendor/version/A.0.256.uavcan', '@sealed')
 
     with raises(_dsdl_definition.FileNameFormatError):
-        standalone('vendor/version/A.0..256.uavcan', '')
+        standalone('vendor/version/A.0..256.uavcan', '@sealed')
 
     with raises(_error.InvalidDefinitionError, match='(?i).*version number.*'):
-        standalone('vendor/version/A.256.0.uavcan', '')
+        standalone('vendor/version/A.256.0.uavcan', '@sealed')
 
     with raises(_parser.DSDLSyntaxError):
-        standalone('vendor/types/A.1.0.uavcan', 'truncated uavcan.node.Heartbeat.1.0 field')
+        standalone('vendor/types/A.1.0.uavcan', 'truncated uavcan.node.Heartbeat.1.0 field\n@sealed')
 
     with raises(_serializable._primitive.InvalidCastModeError):
-        standalone('vendor/types/A.1.0.uavcan', 'truncated bool foo')
+        standalone('vendor/types/A.1.0.uavcan', 'truncated bool foo\n@sealed')
 
     with raises(_serializable._primitive.InvalidCastModeError):
-        standalone('vendor/types/A.1.0.uavcan', 'truncated int8 foo')
+        standalone('vendor/types/A.1.0.uavcan', 'truncated int8 foo\n@sealed')
 
     with raises(_data_type_builder.UndefinedDataTypeError, match=r'(?i).*nonexistent.TypeName.*1\.0.*'):
-        standalone('vendor/types/A.1.0.uavcan', 'nonexistent.TypeName.1.0 field')
+        standalone('vendor/types/A.1.0.uavcan', 'nonexistent.TypeName.1.0 field\n@sealed')
 
     with raises(_data_type_builder.UndefinedDataTypeError, match=r"(?i).*vendor[/\\]+types' instead of .*vendor'.*"):
-        standalone('vendor/types/A.1.0.uavcan', 'types.Nonexistent.1.0 field')
+        standalone('vendor/types/A.1.0.uavcan', 'types.Nonexistent.1.0 field\n@sealed')
 
     with raises(_error.InvalidDefinitionError, match=r'(?i).*not defined for.*'):
         standalone('vendor/types/A.1.0.uavcan',
@@ -399,6 +401,7 @@ def _unittest_error() -> None:
                    int8 a
                    @assert _offset_.count >= 1
                    int16 b
+                   @sealed
                    '''))
 
     with raises(_error.InvalidDefinitionError, match=r'(?i).*field offset is not defined for unions.*'):
@@ -409,62 +412,64 @@ def _unittest_error() -> None:
                    int16 b
                    @assert _offset_.count >= 1
                    int8 c
+                   @sealed
                    '''))
 
     with raises(_data_type_builder.UndefinedDataTypeError, match=r'.*ns.Type_.*1\.0'):
         _parse_definition(
-            _define('vendor/types/A.1.0.uavcan', 'ns.Type_.1.0 field'),
+            _define('vendor/types/A.1.0.uavcan', 'ns.Type_.1.0 field\n@sealed'),
             [
-                _define('ns/Type_.2.0.uavcan', ''),
+                _define('ns/Type_.2.0.uavcan', '@sealed'),
             ]
         )
 
     with raises(_error.InvalidDefinitionError, match='(?i).*Bit length cannot exceed.*'):
         _parse_definition(
-            _define('vendor/types/A.1.0.uavcan', 'int128 field'),
+            _define('vendor/types/A.1.0.uavcan', 'int128 field\n@sealed'),
             [
-                _define('ns/Type_.2.0.uavcan', ''),
-                _define('ns/Type_.1.1.uavcan', ''),
+                _define('ns/Type_.2.0.uavcan', '@sealed'),
+                _define('ns/Type_.1.1.uavcan', '@sealed'),
             ]
         )
 
     with raises(_error.InvalidDefinitionError, match='(?i).*type.*'):
         _parse_definition(
-            _define('vendor/invalid_constant_value/A.1.0.uavcan', 'ns.Type_.1.1 VALUE = 123'),
+            _define('vendor/invalid_constant_value/A.1.0.uavcan', 'ns.Type_.1.1 VALUE = 123\n@sealed'),
             [
-                _define('ns/Type_.2.0.uavcan', ''),
-                _define('ns/Type_.1.1.uavcan', ''),
+                _define('ns/Type_.2.0.uavcan', '@sealed'),
+                _define('ns/Type_.1.1.uavcan', '@sealed'),
             ]
         )
 
     with raises(_data_type_builder.UndefinedDataTypeError):
         defs = [
-            _define('vendor/circular_dependency/A.1.0.uavcan', 'B.1.0 b'),
-            _define('vendor/circular_dependency/B.1.0.uavcan', 'A.1.0 b'),
+            _define('vendor/circular_dependency/A.1.0.uavcan', 'B.1.0 b\n@sealed'),
+            _define('vendor/circular_dependency/B.1.0.uavcan', 'A.1.0 b\n@sealed'),
         ]
         _parse_definition(defs[0], defs)
 
     with raises(_error.InvalidDefinitionError, match='(?i).*union directive.*'):
         _parse_definition(
-            _define('vendor/misplaced_directive/A.1.0.uavcan', 'ns.Type_.2.0 field\n@union'),
+            _define('vendor/misplaced_directive/A.1.0.uavcan', 'ns.Type_.2.0 field\n@union\n@sealed'),
             [
-                _define('ns/Type_.2.0.uavcan', ''),
+                _define('ns/Type_.2.0.uavcan', '@sealed'),
             ]
         )
 
     with raises(_error.InvalidDefinitionError, match='(?i).*deprecated directive.*'):
         _parse_definition(
-            _define('vendor/misplaced_directive/A.1.0.uavcan', 'ns.Type_.2.0 field\n@deprecated'),
+            _define('vendor/misplaced_directive/A.1.0.uavcan', 'ns.Type_.2.0 field\n@deprecated\n@sealed'),
             [
-                _define('ns/Type_.2.0.uavcan', ''),
+                _define('ns/Type_.2.0.uavcan', '@sealed'),
             ]
         )
 
     with raises(_error.InvalidDefinitionError, match='(?i).*deprecated directive.*'):
         _parse_definition(
-            _define('vendor/misplaced_directive/A.1.0.uavcan', 'ns.Type_.2.0 field\n---\n@deprecated'),
+            _define('vendor/misplaced_directive/A.1.0.uavcan',
+                    'ns.Type_.2.0 field\n@sealed\n---\n@deprecated\n@sealed'),
             [
-                _define('ns/Type_.2.0.uavcan', ''),
+                _define('ns/Type_.2.0.uavcan', '@sealed'),
             ]
         )
 
@@ -475,6 +480,7 @@ def _unittest_error() -> None:
                    # Empty
                    @assert false  # Will error here, line number 4
                    # Blank
+                   @sealed
                    '''))
     except _error.FrontendError as ex:
         assert ex.path and ex.path.endswith(os.path.join('vendor', 'types', 'A.1.0.uavcan'))
@@ -482,15 +488,15 @@ def _unittest_error() -> None:
     else:  # pragma: no cover
         assert False
 
-    standalone('vendor/types/1.A.1.0.uavcan', '', allow_unregulated=True)
+    standalone('vendor/types/1.A.1.0.uavcan', '@sealed', allow_unregulated=True)
     with raises(_data_type_builder.UnregulatedFixedPortIDError, match=r'.*allow_unregulated_fixed_port_id.*'):
-        standalone('vendor/types/1.A.1.0.uavcan', '')
+        standalone('vendor/types/1.A.1.0.uavcan', '@sealed')
 
-    standalone('vendor/types/1.A.1.0.uavcan', '---', allow_unregulated=True)
+    standalone('vendor/types/1.A.1.0.uavcan', '@sealed\n---\n@sealed', allow_unregulated=True)
     with raises(_data_type_builder.UnregulatedFixedPortIDError, match=r'.*allow_unregulated_fixed_port_id.*'):
-        standalone('vendor/types/1.A.1.0.uavcan', '---')
+        standalone('vendor/types/1.A.1.0.uavcan', '@sealed\n---\n@sealed')
 
-    with raises(_error.InvalidDefinitionError, match='(?i).*extent.*sealed.*'):
+    with raises(_error.InvalidDefinitionError, match='(?i).*seal.*'):
         standalone('vendor/sealing/A.1.0.uavcan',
                    dedent('''
                    int8 a
@@ -498,7 +504,7 @@ def _unittest_error() -> None:
                    @sealed
                    '''))
 
-    with raises(_error.InvalidDefinitionError, match='(?i).*extent.*sealed.*'):
+    with raises(_error.InvalidDefinitionError, match='(?i).*extent.*'):
         standalone('vendor/sealing/A.1.0.uavcan',
                    dedent('''
                    int8 a
@@ -534,7 +540,7 @@ def _unittest_error() -> None:
                    @extent {16}  # Wrong type
                    '''))
 
-    with raises(_error.InvalidDefinitionError, match='(?i).*extent.*attribute.*'):
+    with raises(_error.InvalidDefinitionError, match='(?i).*extent.*'):
         standalone('vendor/sealing/A.1.0.uavcan',
                    dedent('''
                    int16 a
@@ -581,72 +587,6 @@ def _unittest_print() -> None:
     assert printed_items[1] == "{8}"
 
 
-@_in_n_out
-def _unittest_explicit_extent_diagnostic() -> None:
-    printed_items = None  # type: typing.Optional[typing.Tuple[int, str]]
-
-    def print_handler(line_number: int, text: str) -> None:
-        nonlocal printed_items
-        printed_items = line_number, text
-
-    _define(
-        'ns/A.1.0.uavcan',
-        'uint64 x\n'
-    ).read([], print_handler, False)
-    assert printed_items
-    assert 1 <= printed_items[0] <= 2
-    assert '@extent 12 * 8' in printed_items[1]
-    printed_items = None
-
-    _define(
-        'ns/A.1.0.uavcan',
-        'uint64 x\n'
-        '---\n'
-        'uint64 x\n'
-    ).read([], print_handler, False)
-    assert printed_items
-    assert 1 <= printed_items[0] <= 2
-    assert 'Response' in printed_items[1]
-    assert '@extent 12 * 8' in printed_items[1]
-    printed_items = None
-
-    _define(
-        'ns/A.1.0.uavcan',
-        'uint64 x\n'
-        '---\n'
-        '@sealed\n'
-    ).read([], print_handler, False)
-    assert printed_items
-    assert 1 <= printed_items[0] <= 2
-    assert 'Request' in printed_items[1]
-    assert '@extent 12 * 8' in printed_items[1]
-    printed_items = None
-
-    _define(
-        'ns/A.1.0.uavcan',
-        'uint64 x\n'
-        '@extent 1024\n'
-        '---\n'
-        'uint64 x\n'
-        '@sealed\n'
-    ).read([], print_handler, False)
-    assert not printed_items
-
-    _define(
-        'ns/A.1.0.uavcan',
-        'uint64 x\n'
-        '@sealed\n'
-    ).read([], print_handler, False)
-    assert not printed_items
-
-    _define(
-        'ns/A.1.0.uavcan',
-        'uint64 x\n'
-        '@extent 1024\n'
-    ).read([], print_handler, False)
-    assert not printed_items
-
-
 # noinspection PyProtectedMember
 @_in_n_out
 def _unittest_assert() -> None:
@@ -681,6 +621,7 @@ def _unittest_assert() -> None:
             @assert Array.1.0._bit_length_.max == 8 + 8 + 8
             @assert Array.1.0._extent_ == 8 + 8 + 8
             @assert Array.1.0._extent_ == Array.1.0._bit_length_.max
+            @sealed
             ''')),
         [
             _define('ns/Array.1.0.uavcan', 'uint8[<=2] foo\n@sealed')
@@ -694,6 +635,7 @@ def _unittest_assert() -> None:
                 dedent('''
                 uint64 big
                 @assert _offset_ == 64
+                @sealed
                 ''')),
             []
         )
@@ -702,7 +644,7 @@ def _unittest_assert() -> None:
         _parse_definition(
             _define('ns/C.1.0.uavcan', '@print Service.1.0._bit_length_'),
             [
-                _define('ns/Service.1.0.uavcan', 'uint8 a\n---\nuint16 b')
+                _define('ns/Service.1.0.uavcan', 'uint8 a\n@sealed\n---\nuint16 b\n@sealed')
             ]
         )
 
@@ -710,7 +652,7 @@ def _unittest_assert() -> None:
         _parse_definition(
             _define(
                 'ns/C.1.0.uavcan',
-                '''uint64 LENGTH = uint64.nonexistent_attribute'''),
+                '''uint64 LENGTH = uint64.nonexistent_attribute\n@extent 0'''),
             []
         )
 
@@ -718,18 +660,18 @@ def _unittest_assert() -> None:
         _parse_definition(
             _define(
                 'ns/C.1.0.uavcan',
-                'void2 name'),
+                'void2 name\n@sealed'),
             []
         )
 
     with raises(_serializable._attribute.InvalidConstantValueError):
-        _parse_definition(_define('ns/C.1.0.uavcan', 'int8 name = true'), [])
+        _parse_definition(_define('ns/C.1.0.uavcan', 'int8 name = true\n@sealed'), [])
 
     with raises(_error.InvalidDefinitionError, match='.*value.*'):
         _parse_definition(
             _define(
                 'ns/C.1.0.uavcan',
-                'int8 name = {1, 2, 3}'),
+                'int8 name = {1, 2, 3}\n@sealed'),
             []
         )
 
@@ -741,6 +683,7 @@ def _unittest_assert() -> None:
             float32 a
             uint64 b
             @assert _offset_ == {40, 72}
+            @sealed
             ''')),
         []
     )
@@ -757,6 +700,7 @@ def _unittest_assert() -> None:
             uint8 C = 2
             @assert _offset_ == {40, 72}
             uint8 D = 3
+            @sealed
             ''')),
         []
     )
@@ -771,6 +715,7 @@ def _unittest_assert() -> None:
                 float32 a
                 uint64 b
                 @assert _offset_ == {40, 72}
+                @sealed
                 ''')),
             []
         )
@@ -782,6 +727,7 @@ def _unittest_assert() -> None:
                 dedent('''
                 float32 a
                 @assert _offset_.min == 8
+                @sealed
                 ''')),
             []
         )
@@ -793,6 +739,7 @@ def _unittest_assert() -> None:
                 dedent('''
                 float32 a
                 @assert _offset_.min
+                @sealed
                 ''')),
             []
         )
@@ -806,6 +753,7 @@ def _unittest_assert() -> None:
             @assert J.1.0._bit_length_ == {0, 1, 2, 3, 4, 5, 6, 7, 8} * 8 + 32
             @assert K.1.0._extent_ == 8
             @assert K.1.0._bit_length_ == {8}
+            @sealed
             ''')
         ),
         [
@@ -833,6 +781,7 @@ def _unittest_assert() -> None:
             @assert _offset_ == {17}
             M.1.0 variable
             @assert _offset_ == 32 + {24, 32, 40}  # Aligned; variability due to extensibility (non-sealing)
+            @sealed
             ''')
         ),
         [
@@ -1190,11 +1139,11 @@ def _unittest_parse_namespace_versioning() -> None:
     )
 
     # These are needed to ensure full branch coverage, see the checking code.
-    _define('ns/Empty.1.0.uavcan', '')
-    _define('ns/Empty.1.1.uavcan', '')
-    _define('ns/Empty.2.0.uavcan', '')
-    _define('ns/6800.Empty.3.0.uavcan', '')
-    _define('ns/6801.Empty.4.0.uavcan', '')
+    _define('ns/Empty.1.0.uavcan', '@extent 0')
+    _define('ns/Empty.1.1.uavcan', '@extent 0')
+    _define('ns/Empty.2.0.uavcan', '@extent 0')
+    _define('ns/6800.Empty.3.0.uavcan', '@extent 0')
+    _define('ns/6801.Empty.4.0.uavcan', '@extent 0')
 
     parsed = _namespace.read_namespace(os.path.join(directory.name, 'ns'), [])     # no error
     assert len(parsed) == 8
@@ -1401,12 +1350,13 @@ def _unittest_inconsistent_deprecation() -> None:
     from pytest import raises
 
     _parse_definition(
-        _define('ns/A.1.0.uavcan', ''),
+        _define('ns/A.1.0.uavcan', '@sealed'),
         [
             _define('ns/B.1.0.uavcan',
                     dedent('''
                     @deprecated
                     A.1.0 a
+                    @sealed
                     '''))
         ]
     )
@@ -1417,10 +1367,11 @@ def _unittest_inconsistent_deprecation() -> None:
                 'ns/C.1.0.uavcan',
                 dedent('''
                 X.1.0 b
+                @sealed
                 ''')
             ),
             [
-                _define('ns/X.1.0.uavcan', '@deprecated')
+                _define('ns/X.1.0.uavcan', '@deprecated\n@sealed')
             ]
         )
 
@@ -1429,9 +1380,10 @@ def _unittest_inconsistent_deprecation() -> None:
                 dedent('''
                 @deprecated
                 X.1.0 b
+                @sealed
                 ''')),
         [
-            _define('ns/X.1.0.uavcan', '@deprecated')
+            _define('ns/X.1.0.uavcan', '@deprecated\n@sealed')
         ]
     )
 
@@ -1447,6 +1399,7 @@ def _unittest_repeated_directives() -> None:
                 @deprecated
                 int8 a
                 float16 b
+                @sealed
                 ''')),
         []
     )
@@ -1457,6 +1410,7 @@ def _unittest_repeated_directives() -> None:
                     dedent('''
                     @deprecated
                     @deprecated
+                    @sealed
                     ''')),
             []
         )
@@ -1466,8 +1420,10 @@ def _unittest_repeated_directives() -> None:
             _define('ns/A.1.0.uavcan',
                     dedent('''
                     @deprecated
+                    @sealed
                     ---
                     @deprecated
+                    @sealed
                     ''')),
             []
         )
@@ -1478,10 +1434,12 @@ def _unittest_repeated_directives() -> None:
                 @union
                 int8 a
                 float16 b
+                @sealed
                 ---
                 @union
                 int8 a
                 float16 b
+                @sealed
                 ''')),
         []
     )
@@ -1494,6 +1452,7 @@ def _unittest_repeated_directives() -> None:
                     @union
                     int8 a
                     float16 b
+                    @sealed
                     ''')),
             []
         )
@@ -1506,6 +1465,7 @@ def _unittest_repeated_directives() -> None:
                     @sealed
                     int8 a
                     float16 b
+                    @sealed
                     ''')),
             []
         )
@@ -1518,6 +1478,7 @@ def _unittest_repeated_directives() -> None:
                     float16 b
                     @extent 256
                     @extent 800
+                    @sealed
                     ''')),
             []
         )
@@ -1545,10 +1506,11 @@ def _unittest_dsdl_parser_basics() -> None:
                 @assert true
                 @assert ns.Foo.1.0.THE_CONSTANT == 42
                 @assert ns.Bar.1.23.B == ns.Bar.1.23.A + 1
+                @extent 32 * 1024 * 8
                 ''')),
         [
-            _define('ns/Foo.1.0.uavcan', 'int8 THE_CONSTANT = 42\n'),
-            _define('ns/Bar.1.23.uavcan', 'int8 the_field\nint8 A = 0xA\nint8 B = 0xB'),
+            _define('ns/Foo.1.0.uavcan', 'int8 THE_CONSTANT = 42\n@extent 1024'),
+            _define('ns/Bar.1.23.uavcan', 'int8 the_field\nint8 A = 0xA\nint8 B = 0xB\n@extent 1024'),
         ]
     )
 
@@ -1559,7 +1521,7 @@ def _unittest_dsdl_parser_expressions() -> None:
 
     def throws(definition: str, exc: typing.Type[Exception] = _expression.InvalidOperandError) -> None:
         with raises(exc):
-            _parse_definition(_define('ns/Throws.0.1.uavcan', dedent(definition)), [])
+            _parse_definition(_define('ns/Throws.0.1.uavcan', dedent(definition + '\n@sealed')), [])
 
     throws('bool R = true && 0')
     throws('bool R = true || 0')
@@ -1641,6 +1603,7 @@ def _unittest_dsdl_parser_expressions() -> None:
                 @assert 0xFF_00 & 0x00_FF == 0x0000
                 @assert 0xFF_00 | 0x00_FF == 0xFFFF
                 @assert 0xFF_00 ^ 0x0F_FF == 0xF0FF
+                @sealed
                 ''')),
         []
     )

--- a/pydsdl/_test.py
+++ b/pydsdl/_test.py
@@ -548,6 +548,13 @@ def _unittest_error() -> None:
                    int8 b
                    '''))
 
+    with raises(_error.InvalidDefinitionError, match='(?i).*extent.*'):  # Neither extent nor sealed are specified.
+        standalone('vendor/sealing/A.1.0.uavcan',
+                   dedent('''
+                   int16 a
+                   int8 b
+                   '''))
+
 
 @_in_n_out
 def _unittest_print() -> None:


### PR DESCRIPTION
If neither extent nor sealing is specified, we report an error (per https://github.com/UAVCAN/specification/pull/102). The error hints the user that maybe `@extent` is the way to go, with the suggested value computed as follows:

https://github.com/UAVCAN/pydsdl/blob/8a6d9b5fb0be8ca9ddcb37e60fc2349b35903fab/pydsdl/_data_type_builder.py#L320-L325

Since this is an implementation-specific behavior, we can change it on a whim at any moment if found suboptimal.

@thirtytwobits please confirm the logic. There is no need to look at the code.