### PR TITLE
Add a convenience property CompositeType.inner_type to reduce boilerplate

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -6,7 +6,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = '1.9.0'
+__version__ = '1.9.1'
 __version_info__ = tuple(map(int, __version__.split('.')))
 __license__ = 'MIT'
 __author__ = 'UAVCAN Development Team'


### PR DESCRIPTION
Currently, inner_type is defined only for DelimitedType. This changeset makes it a CompositeType property that returns a reference to self unless self is DelimitedType.