### PR TITLE
Make DelimitedType.delimiter_header_type truncated (not saturated)

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -6,7 +6,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = '1.9.1'
+__version__ = '1.9.2'
 __version_info__ = tuple(map(int, __version__.split('.')))
 __license__ = 'MIT'
 __author__ = 'UAVCAN Development Team'


### PR DESCRIPTION
This allows code generators to avoid emitting unnecessary saturation code. Also, the type is now constructed only once to stay consistent with unions and variable-length arrays.