### PR TITLE
Speed up import

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -7,7 +7,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = "1.10.2"
+__version__ = "1.10.3"
 __version_info__ = tuple(map(int, __version__.split(".")))
 __license__ = "MIT"
 __author__ = "UAVCAN Consortium"


### PR DESCRIPTION
Fix #29

Also, remove unnecessary dev scaffolding.

Before:

    import time:       658 |     216301 | pydsdl

After:

    import time:      3118 |      90038 | pydsdl

216 ms -> 90 ms

This is important for command-line tools like Nunavut and Yakut