### PR TITLE
Add doc attributes to composite and attribute types

### DIFF
--- a/pydsdl/__init__.py
+++ b/pydsdl/__init__.py
@@ -7,7 +7,7 @@
 import os as _os
 import sys as _sys
 
-__version__ = "1.10.3"
+__version__ = "1.11.0"
 __version_info__ = tuple(map(int, __version__.split(".")))
 __license__ = "MIT"
 __author__ = "UAVCAN Consortium"

--- a/pydsdl/_data_schema_builder.py
+++ b/pydsdl/_data_schema_builder.py
@@ -82,23 +82,8 @@ class DataSchemaBuilder:
         assert isinstance(out, _bit_length_set.BitLengthSet) and len(out) > 0
         return out
 
-    def add_comment(self, comment: str, last_line_was_empty: bool) -> None:
-        # TODO: Clean up, kind of hacky; better parsing solution?
-        if self._last_attribute == None:
-            # No attributes yet; this is the toplevel composite type documentation
-            if self.doc != "":
-                self.doc += "\n"
-            self.doc += comment
-        else:
-            # Append comment to attribute
-            if last_line_was_empty:
-                # For now, we throw away floating comments not attached to attributes
-                return
-
-            if self._last_attribute.doc != "":
-                self._last_attribute.doc += "\n"
-            self._last_attribute.doc += comment
-
+    def set_comment(self, comment: str) -> None:
+        self.doc = comment
 
     def add_field(self, field: _serializable.Field) -> None:
         if self.union and self._bit_length_computed_at_least_once:
@@ -107,12 +92,10 @@ class DataSchemaBuilder:
                 "Inter-field offset is not defined for unions; " "previously performed bit length analysis is invalid"
             )
         assert isinstance(field, _serializable.Field)
-        self._last_attribute = field
         self._fields.append(field)
 
     def add_constant(self, constant: _serializable.Constant) -> None:
         assert isinstance(constant, _serializable.Constant)
-        self._last_attribute = constant
         self._constants.append(constant)
 
     def set_serialization_mode(self, mode: SerializationMode) -> None:

--- a/pydsdl/_data_schema_builder.py
+++ b/pydsdl/_data_schema_builder.py
@@ -36,11 +36,10 @@ class DataSchemaBuilder:
     def __init__(self) -> None:
         self._fields = []  # type: typing.List[_serializable.Field]
         self._constants = []  # type: typing.List[_serializable.Constant]
-        self._last_attribute = None # type: typing.Optional[_serializable.Attribute]
         self._serialization_mode = None  # type: typing.Optional[SerializationMode]
         self._is_union = False
         self._bit_length_computed_at_least_once = False
-        self.doc = ""
+        self._doc = ""
 
     @property
     def fields(self) -> typing.List[_serializable.Field]:
@@ -58,6 +57,10 @@ class DataSchemaBuilder:
         out += self.fields
         out += self.constants
         return out
+
+    @property
+    def doc(self) -> str:
+        return self._doc
 
     @property
     def serialization_mode(self) -> typing.Optional[SerializationMode]:
@@ -83,7 +86,7 @@ class DataSchemaBuilder:
         return out
 
     def set_comment(self, comment: str) -> None:
-        self.doc = comment
+        self._doc = comment
 
     def add_field(self, field: _serializable.Field) -> None:
         if self.union and self._bit_length_computed_at_least_once:

--- a/pydsdl/_data_type_builder.py
+++ b/pydsdl/_data_type_builder.py
@@ -122,6 +122,9 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
                     )
         return out
 
+    def on_comment(self, comment: str, last_line_was_empty: bool = False) -> None:
+        self._structs[-1].add_comment(comment, last_line_was_empty)
+
     def on_constant(self, constant_type: _serializable.SerializableType, name: str, value: _expression.Any) -> None:
         self._on_attribute()
         self._structs[-1].add_constant(_serializable.Constant(constant_type, name, value))
@@ -327,6 +330,9 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
                 "`@extent %d * 8`"
                 % (inner.short_name, inner.extent, inner.extent // 8, DataTypeBuilder._suggest_extent_in_bytes(inner))
             )
+
+        out.doc = builder.doc
+
         return out
 
     @staticmethod

--- a/pydsdl/_data_type_builder.py
+++ b/pydsdl/_data_type_builder.py
@@ -53,7 +53,7 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
         self._lookup_definitions = list(lookup_definitions)
         self._print_output_handler = print_output_handler
         self._allow_unregulated_fixed_port_id = allow_unregulated_fixed_port_id
-        self._element_callback = None # type: typing.Callable[[str], _serializable.Attribute]
+        self._element_callback = None  # type: typing.Optional[typing.Callable[[str], None]]
 
         assert isinstance(self._definition, _dsdl_definition.DSDLDefinition)
         assert all(map(lambda x: isinstance(x, _dsdl_definition.DSDLDefinition), lookup_definitions))
@@ -134,25 +134,17 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
     def on_constant(self, constant_type: _serializable.SerializableType, name: str, value: _expression.Any) -> None:
         self._on_attribute()
         self._queue_attribute(
-            lambda doc: self._structs[-1].add_constant(
-                _serializable.Constant(constant_type, name, value, doc)
-            )
+            lambda doc: self._structs[-1].add_constant(_serializable.Constant(constant_type, name, value, doc))
         )
 
     def on_field(self, field_type: _serializable.SerializableType, name: str) -> None:
         self._on_attribute()
-        self._queue_attribute(
-            lambda doc: self._structs[-1].add_field(
-                _serializable.Field(field_type, name, doc)
-            )
-        )
+        self._queue_attribute(lambda doc: self._structs[-1].add_field(_serializable.Field(field_type, name, doc)))
 
     def on_padding_field(self, padding_field_type: _serializable.VoidType) -> None:
         self._on_attribute()
         self._queue_attribute(
-            lambda doc: self._structs[-1].add_field(
-                _serializable.PaddingField(padding_field_type, doc)
-            )
+            lambda doc: self._structs[-1].add_field(_serializable.PaddingField(padding_field_type, doc))
         )
 
     def on_directive(
@@ -237,7 +229,7 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
             allow_unregulated_fixed_port_id=self._allow_unregulated_fixed_port_id,
         )
 
-    def _queue_attribute(self, element_callback: typing.Callable) -> None:
+    def _queue_attribute(self, element_callback: typing.Callable[[str], None]) -> None:
         self._flush_attribute("")
         self._element_callback = element_callback
 
@@ -341,7 +333,7 @@ class DataTypeBuilder(_parser.StatementStreamProcessor):
             fixed_port_id=fixed_port_id,
             source_file_path=source_file_path,
             has_parent_service=has_parent_service,
-            doc=builder.doc
+            doc=builder.doc,
         )  # type: _serializable.CompositeType
         sm = builder.serialization_mode
         if isinstance(sm, _data_schema_builder.DelimitedSerializationMode):

--- a/pydsdl/_parser.py
+++ b/pydsdl/_parser.py
@@ -52,6 +52,7 @@ class StatementStreamProcessor:
     processed DSDL definition.
     This interface can be used to construct a more abstract intermediate representation of the processed text.
     """
+
     def on_header_comment(self, comment: str) -> None:
         raise NotImplementedError  # pragma: no cover
 
@@ -146,7 +147,7 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
         return self._current_line_number
 
     # Misc. helpers
-    def _flush_comment(self):
+    def _flush_comment(self) -> None:
         if self._comment_is_header:
             self._statement_stream_processor.on_header_comment(self._comment)
         else:
@@ -158,7 +159,7 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
         """If the node has children, replace the node with them."""
         return tuple(children) or node
 
-    def visit_line(self, node: _Node, children: _Children) -> int:
+    def visit_line(self, node: _Node, children: _Children) -> None:
         if len(node.text) == 0:
             # Line is empty, flush comment
             self._flush_comment()
@@ -198,7 +199,7 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
 
     def visit_statement_service_response_marker(self, _n: _Node, _c: _Children) -> None:
         self._flush_comment()
-        self._comment_is_header = True # Allow response header comment
+        self._comment_is_header = True  # Allow response header comment
         self._statement_stream_processor.on_service_response_marker()
 
     def visit_statement_directive_with_expression(self, _n: _Node, children: _Children) -> None:

--- a/pydsdl/_parser.py
+++ b/pydsdl/_parser.py
@@ -52,7 +52,10 @@ class StatementStreamProcessor:
     processed DSDL definition.
     This interface can be used to construct a more abstract intermediate representation of the processed text.
     """
-    def on_comment(self, comment: str) -> None:
+    def on_header_comment(self, comment: str) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    def on_attribute_comment(self, comment: str) -> None:
         raise NotImplementedError  # pragma: no cover
 
     def on_constant(self, constant_type: _serializable.SerializableType, name: str, value: _expression.Any) -> None:
@@ -133,14 +136,23 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
         assert isinstance(statement_stream_processor, StatementStreamProcessor)
         self._statement_stream_processor = statement_stream_processor  # type: StatementStreamProcessor
         self._current_line_number = 1  # Lines are numbered from one
-        self._last_line_was_empty = False
         self._comment = ""
+        self._comment_is_header = True
         super().__init__()
 
     @property
     def current_line_number(self) -> int:
         assert self._current_line_number > 0
         return self._current_line_number
+
+    # Misc. helpers
+    def _flush_comment(self):
+        if self._comment_is_header:
+            self._statement_stream_processor.on_header_comment(self._comment)
+        else:
+            self._statement_stream_processor.on_attribute_comment(self._comment)
+        self._comment_is_header = False
+        self._comment = ""
 
     def generic_visit(self, node: _Node, children: typing.Sequence[typing.Any]) -> typing.Any:
         """If the node has children, replace the node with them."""
@@ -149,8 +161,7 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
     def visit_line(self, node: _Node, children: _Children) -> int:
         if len(node.text) == 0:
             # Line is empty, flush comment
-            self._statement_stream_processor.on_comment(self._comment)
-            self._comment = ""
+            self._flush_comment()
 
     def visit_end_of_line(self, _n: _Node, _c: _Children) -> None:
         self._current_line_number += 1
@@ -170,34 +181,30 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
         constant_type, _sp0, name, _sp1, _eq, _sp2, exp = children
         assert isinstance(constant_type, _serializable.SerializableType) and isinstance(name, str) and name
         assert isinstance(exp, _expression.Any)
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
         self._statement_stream_processor.on_constant(constant_type, name, exp)
 
     def visit_statement_field(self, _n: _Node, children: _Children) -> None:
         field_type, _space, name = children
         assert isinstance(field_type, _serializable.SerializableType) and isinstance(name, str) and name
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
         self._statement_stream_processor.on_field(field_type, name)
 
     def visit_statement_padding_field(self, _n: _Node, children: _Children) -> None:
         void_type = children[0]
         assert isinstance(void_type, _serializable.VoidType)
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
         self._statement_stream_processor.on_padding_field(void_type)
 
     def visit_statement_service_response_marker(self, _n: _Node, _c: _Children) -> None:
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
+        self._comment_is_header = True # Allow response header comment
         self._statement_stream_processor.on_service_response_marker()
 
     def visit_statement_directive_with_expression(self, _n: _Node, children: _Children) -> None:
         _at, name, _space, exp = children
         assert isinstance(name, str) and name and isinstance(exp, _expression.Any)
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
         self._statement_stream_processor.on_directive(
             line_number=self.current_line_number, directive_name=name, associated_expression_value=exp
         )
@@ -205,16 +212,14 @@ class _ParseTreeProcessor(parsimonious.NodeVisitor):  # pylint: disable=too-many
     def visit_statement_directive_without_expression(self, _n: _Node, children: _Children) -> None:
         _at, name = children
         assert isinstance(name, str) and name
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
         self._statement_stream_processor.on_directive(
             line_number=self.current_line_number, directive_name=name, associated_expression_value=None
         )
 
     def visit_identifier(self, node: _Node, _c: _Children) -> str:
         assert isinstance(node.text, str) and node.text
-        self._statement_stream_processor.on_comment(self._comment) # flush comment
-        self._comment = ""
+        self._flush_comment()
         return node.text
 
     # ================================================== Data types ==================================================

--- a/pydsdl/_serializable/_attribute.py
+++ b/pydsdl/_serializable/_attribute.py
@@ -18,10 +18,10 @@ class InvalidTypeError(TypeParameterError):
 
 
 class Attribute(_expression.Any):
-    def __init__(self, data_type: SerializableType, name: str):
+    def __init__(self, data_type: SerializableType, name: str, doc: str = ""):
         self._data_type = data_type
         self._name = str(name)
-        self.doc = ""
+        self._doc = str(doc)
 
         if isinstance(data_type, VoidType):
             if self._name:
@@ -37,6 +37,11 @@ class Attribute(_expression.Any):
     def name(self) -> str:
         """For padding fields this is an empty string."""
         return self._name
+
+    @property
+    def doc(self) -> str:
+        """Returns the docs for this attribute."""
+        return self._doc
 
     def __hash__(self) -> int:
         return hash((self._data_type, self._name))
@@ -59,16 +64,16 @@ class Field(Attribute):
 
 
 class PaddingField(Field):
-    def __init__(self, data_type: VoidType):
+    def __init__(self, data_type: VoidType, doc: str = ""):
         if not isinstance(data_type, VoidType):
             raise TypeParameterError("Padding fields must be of the void type")
 
-        super().__init__(data_type, "")
+        super().__init__(data_type, "", doc)
 
 
 class Constant(Attribute):
-    def __init__(self, data_type: SerializableType, name: str, value: _expression.Any):
-        super().__init__(data_type, name)
+    def __init__(self, data_type: SerializableType, name: str, value: _expression.Any, doc: str = ""):
+        super().__init__(data_type, name, doc)
 
         if not isinstance(value, _expression.Primitive):
             raise InvalidConstantValueError("The constant value must be a primitive expression value")

--- a/pydsdl/_serializable/_attribute.py
+++ b/pydsdl/_serializable/_attribute.py
@@ -40,7 +40,7 @@ class Attribute(_expression.Any):
 
     @property
     def doc(self) -> str:
-        """Returns the docs for this attribute."""
+        """Docs for this attribute without the leading #."""
         return self._doc
 
     def __hash__(self) -> int:

--- a/pydsdl/_serializable/_attribute.py
+++ b/pydsdl/_serializable/_attribute.py
@@ -21,6 +21,7 @@ class Attribute(_expression.Any):
     def __init__(self, data_type: SerializableType, name: str):
         self._data_type = data_type
         self._name = str(name)
+        self.doc = ""
 
         if isinstance(data_type, VoidType):
             if self._name:

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -75,6 +75,8 @@ class CompositeType(SerializableType):
         self._source_file_path = str(source_file_path)
         self._has_parent_service = bool(has_parent_service)
 
+        self.doc = ""
+
         # Name check
         if not self._name:
             raise InvalidNameError("Composite type name cannot be empty")

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -63,6 +63,7 @@ class CompositeType(SerializableType):
         fixed_port_id: typing.Optional[int],
         source_file_path: str,
         has_parent_service: bool,
+        doc: str = ""
     ):
         super().__init__()
 
@@ -75,7 +76,7 @@ class CompositeType(SerializableType):
         self._source_file_path = str(source_file_path)
         self._has_parent_service = bool(has_parent_service)
 
-        self.doc = ""
+        self._doc = doc
 
         # Name check
         if not self._name:
@@ -152,6 +153,11 @@ class CompositeType(SerializableType):
     def short_name(self) -> str:
         """The last component of the full name, e.g., ``Heartbeat`` of ``uavcan.node.Heartbeat``."""
         return self.name_components[-1]
+
+    @property
+    def doc(self) -> str:
+        """The last component of the full name, e.g., ``Heartbeat`` of ``uavcan.node.Heartbeat``."""
+        return self._doc
 
     @property
     def full_namespace(self) -> str:
@@ -347,6 +353,7 @@ class UnionType(CompositeType):
         fixed_port_id: typing.Optional[int],
         source_file_path: str,
         has_parent_service: bool,
+        doc: str = ""
     ):
         # Proxy all parameters directly to the base type - I wish we could do that
         # with kwargs while preserving the type information
@@ -358,6 +365,7 @@ class UnionType(CompositeType):
             fixed_port_id=fixed_port_id,
             source_file_path=source_file_path,
             has_parent_service=has_parent_service,
+            doc=doc
         )
 
         if self.number_of_variants < self.MIN_NUMBER_OF_VARIANTS:
@@ -504,7 +512,7 @@ class DelimitedType(CompositeType):
 
     _DEFAULT_DELIMITER_HEADER_BIT_LENGTH = 32
 
-    def __init__(self, inner: CompositeType, extent: int):
+    def __init__(self, inner: CompositeType, extent: int, doc: str = ""):
         self._inner = inner
         super().__init__(
             name=inner.full_name,
@@ -514,6 +522,7 @@ class DelimitedType(CompositeType):
             fixed_port_id=inner.fixed_port_id,
             source_file_path=inner.source_file_path,
             has_parent_service=inner.has_parent_service,
+            doc=doc
         )
         self._extent = int(extent)
         if self._extent % self.alignment_requirement != 0:
@@ -618,7 +627,7 @@ class ServiceType(CompositeType):
     which contain the request and the response structure of the service type, respectively.
     """
 
-    def __init__(self, request: CompositeType, response: CompositeType, fixed_port_id: typing.Optional[int]):
+    def __init__(self, request: CompositeType, response: CompositeType, fixed_port_id: typing.Optional[int], doc: str = ""):
         name = request.full_namespace
         consistent = (
             request.full_name.startswith(name)
@@ -650,6 +659,7 @@ class ServiceType(CompositeType):
             fixed_port_id=fixed_port_id,
             source_file_path=request.source_file_path,
             has_parent_service=False,
+            doc=doc
         )
 
     @property

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -512,7 +512,7 @@ class DelimitedType(CompositeType):
 
     _DEFAULT_DELIMITER_HEADER_BIT_LENGTH = 32
 
-    def __init__(self, inner: CompositeType, extent: int, doc: str = ""):
+    def __init__(self, inner: CompositeType, extent: int):
         self._inner = inner
         super().__init__(
             name=inner.full_name,
@@ -522,7 +522,7 @@ class DelimitedType(CompositeType):
             fixed_port_id=inner.fixed_port_id,
             source_file_path=inner.source_file_path,
             has_parent_service=inner.has_parent_service,
-            doc=doc
+            doc=inner.doc
         )
         self._extent = int(extent)
         if self._extent % self.alignment_requirement != 0:

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -63,7 +63,7 @@ class CompositeType(SerializableType):
         fixed_port_id: typing.Optional[int],
         source_file_path: str,
         has_parent_service: bool,
-        doc: str = ""
+        doc: str = "",
     ):
         super().__init__()
 
@@ -353,7 +353,7 @@ class UnionType(CompositeType):
         fixed_port_id: typing.Optional[int],
         source_file_path: str,
         has_parent_service: bool,
-        doc: str = ""
+        doc: str = "",
     ):
         # Proxy all parameters directly to the base type - I wish we could do that
         # with kwargs while preserving the type information
@@ -365,7 +365,7 @@ class UnionType(CompositeType):
             fixed_port_id=fixed_port_id,
             source_file_path=source_file_path,
             has_parent_service=has_parent_service,
-            doc=doc
+            doc=doc,
         )
 
         if self.number_of_variants < self.MIN_NUMBER_OF_VARIANTS:
@@ -522,7 +522,7 @@ class DelimitedType(CompositeType):
             fixed_port_id=inner.fixed_port_id,
             source_file_path=inner.source_file_path,
             has_parent_service=inner.has_parent_service,
-            doc=inner.doc
+            doc=inner.doc,
         )
         self._extent = int(extent)
         if self._extent % self.alignment_requirement != 0:
@@ -659,7 +659,7 @@ class ServiceType(CompositeType):
             fixed_port_id=fixed_port_id,
             source_file_path=request.source_file_path,
             has_parent_service=False,
-            doc=request.doc
+            doc=request.doc,
         )
 
     @property

--- a/pydsdl/_serializable/_composite.py
+++ b/pydsdl/_serializable/_composite.py
@@ -156,7 +156,7 @@ class CompositeType(SerializableType):
 
     @property
     def doc(self) -> str:
-        """The last component of the full name, e.g., ``Heartbeat`` of ``uavcan.node.Heartbeat``."""
+        """The DSDL header comment provided for this data type without the leading #."""
         return self._doc
 
     @property
@@ -627,7 +627,7 @@ class ServiceType(CompositeType):
     which contain the request and the response structure of the service type, respectively.
     """
 
-    def __init__(self, request: CompositeType, response: CompositeType, fixed_port_id: typing.Optional[int], doc: str = ""):
+    def __init__(self, request: CompositeType, response: CompositeType, fixed_port_id: typing.Optional[int]):
         name = request.full_namespace
         consistent = (
             request.full_name.startswith(name)
@@ -659,7 +659,7 @@ class ServiceType(CompositeType):
             fixed_port_id=fixed_port_id,
             source_file_path=request.source_file_path,
             has_parent_service=False,
-            doc=doc
+            doc=request.doc
         )
 
     @property


### PR DESCRIPTION
This PR adds documentation support for #21. It exposes
comments on attributes and composite types (following proto convention
of having the comment come after the attribute) on a `doc: str` property
as described in https://forum.uavcan.org/t/generate-rich-navigable-html-docs-using-nunavut/1163.