### PR TITLE
third_party: update six to 1.16

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,11 @@ environment:
   matrix:
     - job_group: tests
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON: "C:\\Python39-x64"
+      PYTHON: "C:\\Python310-x64"
+
+    - job_group: tests
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PYTHON: "3.10"
 
     - job_group: tests
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
@@ -23,10 +27,14 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       PYTHON: "3.6"
 
+    - job_group: tests
+      APPVEYOR_BUILD_WORKER_IMAGE: macos
+      PYTHON: "3.9"
+
     - job_name: deploy
       job_depends_on: tests
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PYTHON: "3.9"
+      PYTHON: "3.10"
 
   GIT_TOKEN:
     secure: +jQhxLpePj6hdDryfET/XpLo7VL9fhDXVHlwLOPp/nRDYe97TJAfd0XCTuPz1qkT
@@ -49,11 +57,13 @@ for:
       - cmd: 'SET PATH=%PYTHON%\\Scripts;%PATH%'
       - cmd: 'echo %PATH%'
       # Shared config.
-      - python -m pip install --upgrade pip setuptools nox
+      - python -m pip install --upgrade pip setuptools nox typed_ast
+      - python --version
     test_script:
       # GNU/Linux test.
       - sh: nox --non-interactive --error-on-missing-interpreters --session test lint --python $PYTHON
-      - sh: nox --non-interactive --session docs
+      # skip macOS docs build
+      - sh: 'if [ "$APPVEYOR_BUILD_WORKER_IMAGE" != "macos" ]; then nox --non-interactive --session docs; fi'
       # MS Windows test.
       - cmd: nox --forcecolor --non-interactive --error-on-missing-interpreters --session test lint
       # Shared test for all platforms.

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -7,6 +7,7 @@ body {
     max-width: unset;
 }
 
+
 h2 {
     border-bottom: 1px solid #ddd;
     padding-bottom: 0.2em;
@@ -40,4 +41,8 @@ p {
  */
 div, section, img {
     background-color: inherit;
+}
+
+dl.property {
+	width: 100%;
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx           == 3.5.3
-sphinx_rtd_theme == 0.5.1
+sphinx           == 4.4.0
+sphinx_rtd_theme == 1.0.0
 sphinx-computron >= 0.2, < 2.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import nox
 
 
-PYTHONS = ["3.6", "3.7", "3.8", "3.9"]
+PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 """The newest supported Python shall be listed LAST."""
 
 nox.options.error_on_external_run = True
@@ -64,7 +64,7 @@ def test(session):
 def lint(session):
     session.log("Using the newest supported Python: %s", is_latest_python(session))
     session.install(
-        "mypy   == 0.812",
+        "mypy   == 0.931",
         "pylint == 2.7.2",
     )
     session.run(
@@ -84,7 +84,7 @@ def lint(session):
         },
     )
     if is_latest_python(session):
-        session.install("black == 20.8b1")
+        session.install("black == 21.12b0")
         session.run("black", "--check", ".")
 
 

--- a/pydsdl/third_party/six.py
+++ b/pydsdl/third_party/six.py
@@ -29,7 +29,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.15.0"
+__version__ = "1.16.0"
 
 
 # Useful for very coarse version differentiation.
@@ -70,6 +70,11 @@ else:
             # 64-bit
             MAXSIZE = int((1 << 63) - 1)
         del X
+
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
 
 
 def _add_doc(func, doc):
@@ -186,6 +191,11 @@ class _SixMetaPathImporter(object):
             return self
         return None
 
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
+        return None
+
     def __get_module(self, fullname):
         try:
             return self.known_modules[fullname]
@@ -222,6 +232,12 @@ class _SixMetaPathImporter(object):
         self.__get_module(fullname)  # eventually raises ImportError
         return None
     get_source = get_code  # same as get_code
+
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
 
 _importer = _SixMetaPathImporter(__name__)
 


### PR DESCRIPTION
Improves compatibility with Python 3.10

@thirtytwobits Could you share your local environment setup so I can test it correctly? Nevertheless, this updates the bundled six which should theoretically solve the problem.

I'm also working on migrating pyuavcan to support numpy >= 1.20, which allows 3.10 support.